### PR TITLE
Feature: 스프링 시큐리티 및 Jwt 발급 기능 구현 #7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,15 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.32'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
+    implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/jaefan/munpyspring/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/common/config/WebSecurityConfig.java
@@ -1,0 +1,73 @@
+package com.jaefan.munpyspring.common.config;
+
+import static org.springframework.http.HttpMethod.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.jaefan.munpyspring.security.domain.repository.UserDetailsServiceImpl;
+import com.jaefan.munpyspring.security.filter.JsonLoginFilter;
+import com.jaefan.munpyspring.security.filter.JwtAuthenticationFilter;
+import com.jaefan.munpyspring.security.provider.CustomAuthenticationProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+	private final UserDetailsServiceImpl userDetailsServiceImpl;
+	private final AuthenticationSuccessHandler successHandler;
+	private final AuthenticationFailureHandler failureHandler;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() { // 비밀번호 암호화 저장 또는 로그인 요청 비밀번호와 암호화 저장된 사용자 비밀번호 비교 시 사용됨.
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationProvider authenticationProvider() { // 커스텀 UserDetailsService를 authenticationProvider에 등록
+		return new CustomAuthenticationProvider(userDetailsServiceImpl, passwordEncoder());
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(){ // 커스텀 AuthenticationProvider를 authenticationManager에 등록
+		return new ProviderManager(authenticationProvider());
+	}
+
+	@Bean
+	public JsonLoginFilter jsonLoginFilter() {
+		return new JsonLoginFilter(authenticationManager(), successHandler, failureHandler);
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception { // 필터 순서: JsonLoginFilter -> JwtAuthenticationFilter -> UsernamePasswordAuthenticationFilter(비활성화)
+		http
+			.csrf(csrf -> csrf.disable())
+			.cors(cors -> cors.disable())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(POST, "/api/animal").hasRole("SHELTER") // 동물 등록은 보호소만 가능.
+				.anyRequest()
+				.permitAll())
+			.formLogin(form -> form.disable())
+			.addFilterBefore(jsonLoginFilter(), UsernamePasswordAuthenticationFilter.class) // Json 로그인 요청을 처리하는 필터
+			.addFilterBefore(jwtAuthenticationFilter,UsernamePasswordAuthenticationFilter.class); // 요청에 액세스 토큰이 포함되면 토큰 인증을 처리하는 필터
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/common/util/CookieUtil.java
+++ b/src/main/java/com/jaefan/munpyspring/common/util/CookieUtil.java
@@ -1,0 +1,38 @@
+package com.jaefan.munpyspring.common.util;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+
+@Component
+public class CookieUtil {
+
+	private final int accessCookieAge = 30 * 60;
+	private final int refreshCookieAge = 2 * 7 * 24 * 60 * 60;
+
+	public Cookie generateAccessCookie(String accessToken) {
+		return generateCookie("access_token", accessToken, accessCookieAge);
+	}
+
+	public Cookie generateRefreshCookie(String refreshToken) {
+		return generateCookie("refresh_token", refreshToken, refreshCookieAge);
+	}
+
+	private Cookie generateCookie(String name, String content, int age) {
+		Cookie cookie = new Cookie(name, content);
+		cookie.setMaxAge(age);
+		cookie.setPath("/");
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		return cookie;
+	}
+
+	public Cookie deleteCookie(String name) {
+		Cookie cookie = new Cookie(name,null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/");
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		return cookie;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/domain/model/CustomUserDetails.java
+++ b/src/main/java/com/jaefan/munpyspring/security/domain/model/CustomUserDetails.java
@@ -1,0 +1,45 @@
+package com.jaefan.munpyspring.security.domain.model;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.jaefan.munpyspring.user.domain.model.Role;
+import com.jaefan.munpyspring.user.domain.model.User;
+
+import lombok.Getter;
+
+/**
+ * 인증에 필요한 값을 담는 객체
+ */
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+	private String email;
+	private String password;
+	private Role role;
+
+	@Override
+	public String getPassword() {
+		return password;
+	}
+
+	@Override
+	public String getUsername() {
+		return email;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));
+	}
+
+	public CustomUserDetails(User user) {
+		this.email = user.getEmail();
+		this.password = user.getPassword();
+		this.role = user.getRole();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/domain/model/JwtTokens.java
+++ b/src/main/java/com/jaefan/munpyspring/security/domain/model/JwtTokens.java
@@ -1,0 +1,11 @@
+package com.jaefan.munpyspring.security.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtTokens {
+	private String accessToken; // 유효시간: 30분
+	private String refreshToken; // 유효시간: 2주
+}

--- a/src/main/java/com/jaefan/munpyspring/security/domain/repository/UserDetailsServiceImpl.java
+++ b/src/main/java/com/jaefan/munpyspring/security/domain/repository/UserDetailsServiceImpl.java
@@ -1,0 +1,31 @@
+package com.jaefan.munpyspring.security.domain.repository;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.jaefan.munpyspring.security.domain.model.CustomUserDetails;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * email로 loadUserByUsername하기 위한 커스텀 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(email).orElseThrow(() -> new EntityNotFoundException());
+		CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+		return customUserDetails;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/filter/JsonLoginFilter.java
+++ b/src/main/java/com/jaefan/munpyspring/security/filter/JsonLoginFilter.java
@@ -1,0 +1,73 @@
+package com.jaefan.munpyspring.security.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Json 로그인 요청을 처리하는 필터
+ */
+@Component
+@RequiredArgsConstructor
+public class JsonLoginFilter extends OncePerRequestFilter {
+
+	private final AuthenticationManager authenticationManager; // 인증 처리해주는 클래스
+
+	private final AuthenticationSuccessHandler successHandler;
+
+	private final AuthenticationFailureHandler failureHandler;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+		// 필터 체인을 통과하는 요청이 POST "/login"이면 필터가 동작
+		if (!request.getRequestURI().equals("/login") || !request.getMethod().equalsIgnoreCase("POST")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		try {
+			Map<String, String> requestBody = objectMapper.readValue(request.getInputStream(), Map.class);
+			String email = requestBody.get("email");
+			String password = requestBody.get("password");
+
+			if (email == null || password == null) {
+				throw new IllegalArgumentException();
+			}
+
+			Authentication authentication = new UsernamePasswordAuthenticationToken(email, password); // 인증 객체 생성
+			Authentication result = authenticationManager.authenticate(authentication); // 인증 성공 시 AuthenticationException가 발생하지 않음
+			successHandler.onAuthenticationSuccess(request, response, result); // LoginSuccessHandler 호춯
+
+		} catch (AuthenticationException ex) {	// email은 맞지만 비밀번호가 틀린경우
+			failureHandler.onAuthenticationFailure(request, response, ex); // LoginFailureHandler 호출
+
+		} catch (EntityNotFoundException ex) { // 없는 email인 경우
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			response.getWriter().write("입력하신 계정 정보가 존재하지 않습니다.");
+
+		} catch (Exception ex) {
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			response.getWriter().write("입력 형식을 다시 한번 확인해주세요.");
+		}
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jaefan/munpyspring/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.jaefan.munpyspring.security.filter;
+
+import static jakarta.servlet.http.HttpServletResponse.*;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.jaefan.munpyspring.security.provider.JwtProvider;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 요청에 액세스 토큰이 존재하면 토큰 인증을 실행하는 필터.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+
+	/**
+	 * 해당 필터는 JWT Bearer 토큰이 요청에 포함돼 있으면 무조건 동작.
+	 */
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+		String token = getJwtFromRequest(request);
+		try {
+			if (token != null && jwtProvider.isValid(token)) {
+				String email = jwtProvider.getEmail(token);
+
+				if (email != null) {
+					Authentication authentication = jwtProvider.getAuthentication(token); // 토큰을 기반으로 인증 객체를 만드는 메소드
+					SecurityContextHolder.getContext().setAuthentication(authentication); // 인증 처리
+				}
+			}
+		} catch (ExpiredJwtException ex) { // 액세스 토큰이 만료된 경우 /api/refresh로 리다이렉트 요구
+			createErrorResponse(SC_UNAUTHORIZED, "Access token has expired. Redirect to /api/refresh", response);
+			return;
+
+		} catch (JwtException | IllegalArgumentException ex) { // 액세스 토큰이 유효하지 않은 토큰인 경우 로그인 요구
+			createErrorResponse(SC_UNAUTHORIZED, "Access token is invalid please login.", response);
+			return;
+		}
+
+		filterChain.doFilter(request, response); // 다음 필터로 요청 전달
+	}
+
+	private String getJwtFromRequest(HttpServletRequest request) { // 요청에서 Jwt 파싱
+		String bearerToken = request.getHeader("Authorization");
+		if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+
+	private void createErrorResponse(int status, String message, HttpServletResponse response) throws IOException {
+		response.setStatus(status);
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginFailureHandler.java
+++ b/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginFailureHandler.java
@@ -1,0 +1,23 @@
+package com.jaefan.munpyspring.security.filter.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * JsonLoginFilter에서 인증 실패시 동작하는 핸들러.
+ */
+@Component
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write("입력하신 계정 정보가 올바르지 않습니다.");
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginSuccessHandler.java
@@ -1,0 +1,65 @@
+package com.jaefan.munpyspring.security.filter.handler;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jaefan.munpyspring.common.util.CookieUtil;
+import com.jaefan.munpyspring.security.domain.model.JwtTokens;
+import com.jaefan.munpyspring.security.provider.JwtProvider;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtProvider jwtProvider;
+
+	private final CookieUtil cookieUtil;
+
+	private final UserRepository userRepository;
+
+	/**
+	 * JsonLoginFilter 인증 성공 시 동작하는 핸들러 메소드로 액세스, 리프래쉬 토큰을 발급해 쿠키에 HttpOnly로 담아 응답합니다.
+	 */
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+		String email = authentication.getName();
+
+		JwtTokens jwtTokens = jwtProvider.createJwtTokensWithEmail(email); // jwtTokens: 액세스, 리프래쉬를 담는 객체
+
+		updateVisitAt(email); // 로그인 성공 시 최근 접속 정보 업데이트
+
+		Cookie accessTokenCookie = cookieUtil.generateAccessCookie(jwtTokens.getAccessToken());
+		Cookie refreshTokenCookie = cookieUtil.generateRefreshCookie(jwtTokens.getRefreshToken());
+
+		response.addCookie(accessTokenCookie);
+		response.addCookie(refreshTokenCookie);
+
+		response.setStatus(HttpServletResponse.SC_OK);
+		response.getWriter().write("Login Success.");
+	}
+
+	@Transactional
+	private void updateVisitAt(String email) {
+		Optional<User> optionalUser = userRepository.findByEmail(email);
+
+		User user = optionalUser.get();
+
+		user.updateLastVisit();
+
+		userRepository.save(user);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/jaefan/munpyspring/security/filter/handler/LoginSuccessHandler.java
@@ -1,20 +1,16 @@
 package com.jaefan.munpyspring.security.filter.handler;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.jaefan.munpyspring.common.util.CookieUtil;
 import com.jaefan.munpyspring.security.domain.model.JwtTokens;
 import com.jaefan.munpyspring.security.provider.JwtProvider;
-import com.jaefan.munpyspring.user.domain.model.User;
-import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+import com.jaefan.munpyspring.user.application.UserService;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,19 +24,19 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final CookieUtil cookieUtil;
 
-	private final UserRepository userRepository;
+	private final UserService userService;
 
 	/**
 	 * JsonLoginFilter 인증 성공 시 동작하는 핸들러 메소드로 액세스, 리프래쉬 토큰을 발급해 쿠키에 HttpOnly로 담아 응답합니다.
 	 */
 	@Override
-	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
 		String email = authentication.getName();
 
 		JwtTokens jwtTokens = jwtProvider.createJwtTokensWithEmail(email); // jwtTokens: 액세스, 리프래쉬를 담는 객체
 
-		updateVisitAt(email); // 로그인 성공 시 최근 접속 정보 업데이트
+		userService.updateVisitAt(email); // 로그인 성공 시 최근 접속 정보 업데이트
 
 		Cookie accessTokenCookie = cookieUtil.generateAccessCookie(jwtTokens.getAccessToken());
 		Cookie refreshTokenCookie = cookieUtil.generateRefreshCookie(jwtTokens.getRefreshToken());
@@ -50,16 +46,5 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 		response.setStatus(HttpServletResponse.SC_OK);
 		response.getWriter().write("Login Success.");
-	}
-
-	@Transactional
-	private void updateVisitAt(String email) {
-		Optional<User> optionalUser = userRepository.findByEmail(email);
-
-		User user = optionalUser.get();
-
-		user.updateLastVisit();
-
-		userRepository.save(user);
 	}
 }

--- a/src/main/java/com/jaefan/munpyspring/security/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/security/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,45 @@
+package com.jaefan.munpyspring.security.provider;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.jaefan.munpyspring.security.domain.model.CustomUserDetails;
+import com.jaefan.munpyspring.security.domain.repository.UserDetailsServiceImpl;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * WebSecurityConfig에 등록되는 인증 구현체.
+ * 인증이 성공하면 사용자 정보를 기반으로 인증객체인 UsernamePasswordAuthenticationToken을 생성하여 반환합니다.
+ * 이 클래스에서 반환해주는 인증객체를 Spring Security Context Holder에 넣어주면 인증완료.
+ */
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+	private final UserDetailsServiceImpl userDetailsService;
+
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		String email = authentication.getName();
+		String password = (String)authentication.getCredentials();
+
+		CustomUserDetails userDetails = (CustomUserDetails)userDetailsService.loadUserByUsername(email);
+
+		if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+			throw new BadCredentialsException("입력하신 계정 정보가 올바르지 않습니다.");
+		}
+
+		return new UsernamePasswordAuthenticationToken(userDetails,"",userDetails.getAuthorities());
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authentication.equals(UsernamePasswordAuthenticationToken.class);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/security/provider/JwtProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/security/provider/JwtProvider.java
@@ -1,0 +1,99 @@
+package com.jaefan.munpyspring.security.provider;
+
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import com.jaefan.munpyspring.security.domain.model.CustomUserDetails;
+import com.jaefan.munpyspring.security.domain.model.JwtTokens;
+import com.jaefan.munpyspring.security.domain.repository.UserDetailsServiceImpl;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * JWT 토큰 발급 및 파싱을 담당하는 컴포넌트.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+	private final UserDetailsServiceImpl userDetailsService;
+
+	@Value("${spring.jwt.secret}")
+	private String secretKey;
+
+	private long accessTokenValidTime = 30 * 60 * 1000L; // 30분
+
+	private long refreshTokenValidTime = 2 * 7 * 24 * 60 * 60 * 1000L; // 2주
+
+	public String generateAccessToken(String email) {
+		return createToken(email, accessTokenValidTime);
+	}
+
+	public String generateRefreshToken(String email) {
+		return createToken(email, refreshTokenValidTime);
+	}
+
+	public JwtTokens createJwtTokensWithEmail(String email) {
+		String accessToken = generateAccessToken(email);
+		String refreshToken = generateRefreshToken(email);
+		return new JwtTokens(accessToken, refreshToken);
+	}
+
+	public String refreshAccessToken(String refreshToken) { // 리프래쉬 토큰이 유효하면 액세스 토큰을 재발급하는 메소드
+		try {
+			if (isValid(refreshToken)) {
+				String email = getEmail(refreshToken);
+				return generateAccessToken(email);
+			} else {
+				throw new JwtException("token is invalid");
+			}
+		} catch (Exception ex) {
+			throw new JwtException("token is invalid");
+		}
+	}
+
+	private String createToken(String email, Long age) {
+		return Jwts.builder()
+			.setSubject(email)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + age))
+			.claim("email", email)
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+	}
+
+	public boolean isValid(String token) { // 이 함수는 토큰이 유효한 경우 true를 반환하고 아닌 경우 예외가 발생합니다. 이 함수를 호출하는 쪽에서 예외를 catch해 적절히 응답해야 합니다. ex) JwtAuthenticationFilter의 doFilterInternal
+		Jws<Claims> claimsJws = Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token);
+		return true;
+	}
+
+	public String getEmail(String token) {
+		Jws<Claims> claimsJws = getClaims(token);
+		return claimsJws.getBody().getSubject();
+	}
+
+	public Jws<Claims> getClaims(String token) {
+		return Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token);
+	}
+
+	/**
+	 * 토큰을 기반으로 인증 객체를 만드는 메소드. 토큰이 유효한 경우에만 동작.
+	 */
+	public Authentication getAuthentication(String token) {
+		CustomUserDetails userDetails = (CustomUserDetails)userDetailsService.loadUserByUsername(getEmail(token));
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/user/domain/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.jaefan.munpyspring.user.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.jaefan.munpyspring.user.domain.model.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
+
+	Optional<User> findByEmail(String email);
+
+	Optional<User> findByUuid(UUID uuid);
+}


### PR DESCRIPTION
# Feature: 스프링 시큐리티 및 Jwt 발급 기능 구현 #7

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅ 개요
> 로그인에 사용할 Jwt 발급 기능 구현
스프링 시큐리티 필터 체인을 이용해 요청에 대해 인증, 인가

### ✅ 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다.

### ✅ ISSUE 번호
> 관련된 이슈 번호를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- #7

### ✅ 참고 사항
> 1.주석을 추가하긴 했는데, 그래도 리뷰하시는데 이해 안되는 점 있으시면 바로 말씀해주세요!
2.WebSecurityConfig의 http 제한은 일단은 "/api/animal" 이거 하나입니다.
3.jwtProvider는 비밀키를 application.yml에서 주입받는데 아무 긴 문자열을 사용하면 됩니다. ex) spring.jwt.secret : "asdoqwjei123oj32~"
