### PR TITLE
Feature: OAuth 가입 & 보호소 등록 기능 #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3'
+    implementation 'com.google.cloud:google-cloud-storage:2.39.0'
 
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'

--- a/src/main/java/com/jaefan/munpyspring/animal/domain/repository/BreedRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/animal/domain/repository/BreedRepository.java
@@ -1,0 +1,8 @@
+package com.jaefan.munpyspring.animal.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jaefan.munpyspring.animal.domain.model.Breed;
+
+public interface BreedRepository extends JpaRepository<Breed, Long> {
+}

--- a/src/main/java/com/jaefan/munpyspring/common/config/GCSConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/common/config/GCSConfig.java
@@ -1,0 +1,32 @@
+package com.jaefan.munpyspring.common.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ResourceUtils;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+/**
+ * Google Cloud Storage Configuration
+ */
+@Configuration
+public class GCSConfig {
+
+	@Value("${spring.cloud.gcp.storage.credentials.location}")
+	private String keyFileLocation; // Google Cloud Storage 인증 Key File 경로 위치 (실제 경로에 존재해야 함.)
+
+	@Bean
+	public Storage storage() throws IOException { // Google Cloud Storage와 상호작용하기 위한 Storage 클라이언트
+		InputStream keyFile = ResourceUtils.getURL(keyFileLocation).openStream();
+		return StorageOptions.newBuilder()
+			.setCredentials(GoogleCredentials.fromStream(keyFile))
+			.build()
+			.getService();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/common/exception/DuplicateEntityException.java
+++ b/src/main/java/com/jaefan/munpyspring/common/exception/DuplicateEntityException.java
@@ -1,0 +1,7 @@
+package com.jaefan.munpyspring.common.exception;
+
+public class DuplicateEntityException extends RuntimeException {
+	public DuplicateEntityException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jaefan/munpyspring/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+import com.jaefan.munpyspring.user.presentation.exception.OAuthProcessingException;
+
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 
@@ -47,5 +50,22 @@ public class GlobalExceptionHandler {
 		Map<String, String> errorMessages = new HashMap<>();
 		errorMessages.put("max-file-size exceeded", "업로드 가능 용량은 최대 10MB 입니다.");
 		return new ResponseEntity<>(errorMessages, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(DuplicateEntityException.class)
+	public ResponseEntity<Map<String, String>> handleDuplicateEntityException(DuplicateEntityException ex) {
+		Map<String, String> errorMessages = new HashMap<>();
+		errorMessages.put("error", ex.getMessage());
+		return new ResponseEntity<>(errorMessages, HttpStatus.CONFLICT);
+	}
+
+	@ExceptionHandler(OAuthProcessingException.class)
+	public ResponseEntity<String> handleOAuthProcessingException(OAuthProcessingException ex) {
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<String> handleEntityNotFoundException(EntityNotFoundException ex) {
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
 	}
 }

--- a/src/main/java/com/jaefan/munpyspring/common/util/GoogleCloudStroageUploader.java
+++ b/src/main/java/com/jaefan/munpyspring/common/util/GoogleCloudStroageUploader.java
@@ -1,0 +1,52 @@
+package com.jaefan.munpyspring.common.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Google Cloud Storage 이미지 업로더
+ */
+@Component
+@RequiredArgsConstructor
+public class GoogleCloudStroageUploader {
+
+	@Value("${spring.cloud.gcp.storage.bucket}")
+	private String bucketName;
+
+	private final Storage storage;
+
+	public List<String> upload(List<MultipartFile> files, String dirName) throws IOException {
+		List<String> imageUrls = new ArrayList<>();
+
+		for (MultipartFile file : files) {
+			imageUrls.add(upload(file, dirName));
+		}
+		return imageUrls;
+	}
+
+	public String upload(MultipartFile file, String dirName) throws IOException {
+		String uuid = UUID.randomUUID().toString();
+		String ext = file.getContentType();
+		String filePath = dirName + "/" + uuid;
+
+		BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, filePath)
+			.setContentType(ext)
+			.build();
+
+		Blob blob = storage.create(blobInfo, file.getBytes());
+
+		return "https://storage.googleapis.com/" + bucketName + "/" + filePath;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/shelter/application/ShelterService.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/application/ShelterService.java
@@ -45,7 +45,7 @@ public class ShelterService {
 			imageUrl = googleCloudStroageUploader.upload(shelterSignUpRequestDto.getProfileImage(), DIR_NAME);
 		}
 
-		Shelter shelter = ShelterSignUpRequestDto.toShelter(shelterSignUpRequestDto, imageUrl);
+		Shelter shelter = shelterSignUpRequestDto.toShelter(imageUrl);
 
 		shelter.hashPassword(passwordEncoder);
 

--- a/src/main/java/com/jaefan/munpyspring/shelter/application/ShelterService.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/application/ShelterService.java
@@ -1,0 +1,54 @@
+package com.jaefan.munpyspring.shelter.application;
+
+import java.io.IOException;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jaefan.munpyspring.common.exception.DuplicateEntityException;
+import com.jaefan.munpyspring.common.util.GoogleCloudStroageUploader;
+import com.jaefan.munpyspring.shelter.domain.model.Shelter;
+import com.jaefan.munpyspring.shelter.domain.repository.ShelterRepository;
+import com.jaefan.munpyspring.shelter.presentation.dto.ShelterSignUpRequestDto;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShelterService {
+
+	private final ShelterRepository shelterRepository;
+
+	private final UserRepository userRepository;
+
+	private final PasswordEncoder passwordEncoder;
+
+	private final GoogleCloudStroageUploader googleCloudStroageUploader;
+
+	private final static String DIR_NAME = "SHELTER";
+
+	@Transactional
+	public void signUpShelter(ShelterSignUpRequestDto shelterSignUpRequestDto) throws IOException {
+		if (userRepository.existsByEmail(shelterSignUpRequestDto.getEmail())) {
+			throw new DuplicateEntityException("이미 존재하는 이메일입니다.");
+		}
+
+		if (userRepository.existsByNickname(shelterSignUpRequestDto.getNickname())) {
+			throw new DuplicateEntityException("이미 존재하는 닉네임입니다.");
+		}
+
+		String imageUrl = null;
+
+		if (shelterSignUpRequestDto.getProfileImage() != null) {
+			imageUrl = googleCloudStroageUploader.upload(shelterSignUpRequestDto.getProfileImage(), DIR_NAME);
+		}
+
+		Shelter shelter = ShelterSignUpRequestDto.toShelter(shelterSignUpRequestDto, imageUrl);
+
+		shelter.hashPassword(passwordEncoder);
+
+		shelterRepository.save(shelter);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/shelter/domain/model/Shelter.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/domain/model/Shelter.java
@@ -1,42 +1,56 @@
 package com.jaefan.munpyspring.shelter.domain.model;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import com.jaefan.munpyspring.user.domain.model.User;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "shelters")
 public class Shelter {
 	@Id
+	@Column(name = "shelter_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@NotBlank
+	@Column(length = 150, nullable = false)
 	private String name;
 
-	@NotBlank
+	@Column(length = 300, nullable = false)
 	private String address;
 
 	@NotBlank
 	private String owner;
 
-	@NotBlank
+	@Column(length = 13, nullable = false)
 	private String telNo;
 
 	@NotNull
-	@OneToOne
-	@JoinColumn(name = "user_id")
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
+
+	public void hashPassword(PasswordEncoder passwordEncoder) {
+		user.hashPassword(passwordEncoder);
+	}
 }

--- a/src/main/java/com/jaefan/munpyspring/shelter/presentation/ShelterController.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/presentation/ShelterController.java
@@ -17,13 +17,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/shelters")
 @RequiredArgsConstructor
 public class ShelterController {
 
 	private final ShelterService shelterService;
 
-	@PostMapping("/shelter")
+	@PostMapping
 	public ResponseEntity<String> signUpShelter(@Valid @ModelAttribute ShelterSignUpRequestDto shelterSignUpRequestDto) throws IOException {
 		shelterService.signUpShelter(shelterSignUpRequestDto);
 		return new ResponseEntity<>("signUp Success", CREATED);

--- a/src/main/java/com/jaefan/munpyspring/shelter/presentation/ShelterController.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/presentation/ShelterController.java
@@ -1,0 +1,31 @@
+package com.jaefan.munpyspring.shelter.presentation;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jaefan.munpyspring.shelter.application.ShelterService;
+import com.jaefan.munpyspring.shelter.presentation.dto.ShelterSignUpRequestDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ShelterController {
+
+	private final ShelterService shelterService;
+
+	@PostMapping("/shelter")
+	public ResponseEntity<String> signUpShelter(@Valid @ModelAttribute ShelterSignUpRequestDto shelterSignUpRequestDto) throws IOException {
+		shelterService.signUpShelter(shelterSignUpRequestDto);
+		return new ResponseEntity<>("signUp Success", CREATED);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/shelter/presentation/dto/ShelterSignUpRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/presentation/dto/ShelterSignUpRequestDto.java
@@ -1,0 +1,77 @@
+package com.jaefan.munpyspring.shelter.presentation.dto;
+
+import static com.jaefan.munpyspring.user.domain.model.Provider.*;
+import static com.jaefan.munpyspring.user.domain.model.Role.*;
+import static com.jaefan.munpyspring.user.domain.model.Status.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.jaefan.munpyspring.shelter.domain.model.Shelter;
+import com.jaefan.munpyspring.user.domain.model.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 보호소 회원가입 요청 Dto
+ */
+@Getter
+@AllArgsConstructor
+public class ShelterSignUpRequestDto {
+
+	@NotBlank
+	@Pattern(regexp = "^(?! ).*(?<! )$", message = "닉네임의 앞이나 뒤에 공백이 올 수 없습니다.")
+	@Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_ ]{2,50}$", message = "닉네임은 특수문자를 제외한 2~50자리여야 합니다.")
+	private String nickname;
+
+	private MultipartFile profileImage;
+
+	@NotBlank
+	@Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank
+	@Pattern(regexp = "^[\\S]{8,16}$", message = "비밀번호는 8~16자 공백 없이 입력해야 합니다.")
+	private String password;
+
+	@NotBlank
+	@Size(min = 1, max = 300, message = "주소는 300자 이내로 입력해주세요.")
+	private String address;
+
+	@NotBlank
+	private String owner;
+
+	@NotBlank
+	@Pattern(regexp = "^s\\d{2,3}-\\d{3,4}-\\d{4}$|^\\d{4}-\\d{4}$", message = "전화번호는 올바른 형식이어야 합니다. 예: 02-123-1234, 010-1234-5678, 1588-1234")
+	@Size(min = 9, max = 13, message = "전화번호는 최소 8자리, 최대 11자리입니다.") // XXXX-XXXX (8자리), XXX-XXXX-XXXX (11자리)
+	private String telNo;
+
+	public static Shelter toShelter(ShelterSignUpRequestDto shelterSignUpRequestDto, String imageUrl) {
+
+		User user = User.builder()
+			.uuid(UUID.randomUUID())
+			.nickname(shelterSignUpRequestDto.getNickname())
+			.profileImage(imageUrl)
+			.providerType(DEFAULT)
+			.email(shelterSignUpRequestDto.getEmail())
+			.status(ACTIVE)
+			.password(shelterSignUpRequestDto.getPassword())
+			.createdAt(LocalDateTime.now())
+			.role(SHELTER)
+			.build();
+
+		return Shelter.builder()
+			.name(shelterSignUpRequestDto.getNickname())
+			.address(shelterSignUpRequestDto.getAddress())
+			.owner(shelterSignUpRequestDto.getOwner())
+			.telNo(shelterSignUpRequestDto.getTelNo())
+			.user(user)
+			.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/shelter/presentation/dto/ShelterSignUpRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/presentation/dto/ShelterSignUpRequestDto.java
@@ -52,25 +52,25 @@ public class ShelterSignUpRequestDto {
 	@Size(min = 9, max = 13, message = "전화번호는 최소 8자리, 최대 11자리입니다.") // XXXX-XXXX (8자리), XXX-XXXX-XXXX (11자리)
 	private String telNo;
 
-	public static Shelter toShelter(ShelterSignUpRequestDto shelterSignUpRequestDto, String imageUrl) {
+	public Shelter toShelter(String imageUrl) {
 
 		User user = User.builder()
 			.uuid(UUID.randomUUID())
-			.nickname(shelterSignUpRequestDto.getNickname())
+			.nickname(nickname)
 			.profileImage(imageUrl)
 			.providerType(DEFAULT)
-			.email(shelterSignUpRequestDto.getEmail())
+			.email(email)
 			.status(ACTIVE)
-			.password(shelterSignUpRequestDto.getPassword())
+			.password(password)
 			.createdAt(LocalDateTime.now())
 			.role(SHELTER)
 			.build();
 
 		return Shelter.builder()
-			.name(shelterSignUpRequestDto.getNickname())
-			.address(shelterSignUpRequestDto.getAddress())
-			.owner(shelterSignUpRequestDto.getOwner())
-			.telNo(shelterSignUpRequestDto.getTelNo())
+			.name(nickname)
+			.address(address)
+			.owner(owner)
+			.telNo(telNo)
 			.user(user)
 			.build();
 	}

--- a/src/main/java/com/jaefan/munpyspring/user/application/KakaoHttpClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/KakaoHttpClient.java
@@ -1,0 +1,66 @@
+package com.jaefan.munpyspring.user.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.exception.OAuthProcessingException;
+import com.jaefan.munpyspring.user.presentation.feignClient.KakaoTokenFeignClient;
+import com.jaefan.munpyspring.user.presentation.feignClient.KakaoUserProfileFeignClient;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * FeignClient를 사용해 HTTP 요청을 대리 수행해주는 컴포넌트
+ */
+@Component
+@RequiredArgsConstructor
+public class KakaoHttpClient {
+
+	@Value("${oauth2.kakao.api.client-id}")
+	private String clientId;
+
+	@Value("${oauth2.kakao.api.redirect-uri}")
+	private String redirectUri;
+
+	private final ObjectMapper objectMapper;
+
+	private final KakaoTokenFeignClient kakaoTokenFeignClient; // 토큰발급 요청을 보내는 FeignClient
+
+	private final KakaoUserProfileFeignClient kakaoUserProfileFeignClient; // 프로필 정보 요청을 보내는 FeignClient
+
+	public OAuthToken getTokenByCode(String code) {
+		try {
+			return kakaoTokenFeignClient.getKakaoTokenByCode(
+				"authorization_code", // 고정값
+				clientId,
+				redirectUri,
+				code
+			);
+		} catch (Exception ex) {
+			throw new OAuthProcessingException("Failed to process Kakao OAuth");
+		}
+	}
+
+	public OAuthAccountDto getAccountByOAuthToken(String authorization, String propertyKeys) {
+		try {
+			ResponseEntity<String> profileResponse = kakaoUserProfileFeignClient.getKakaoUserProfile(
+				authorization,
+				propertyKeys
+			);
+
+			JsonNode rootNode = objectMapper.readTree(profileResponse.getBody());
+			JsonNode profileNode = rootNode.path("kakao_account").path("profile");
+			String profileImageUrl = profileNode.path("profile_image_url").asText();
+			String email = rootNode.path("kakao_account").path("email").asText();
+
+			return new OAuthAccountDto(profileImageUrl, email);
+		} catch (Exception ex) {
+			throw new OAuthProcessingException("Failed to process Kakao OAuth");
+		}
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/KakaoHttpClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/KakaoHttpClient.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 import com.jaefan.munpyspring.user.presentation.exception.OAuthProcessingException;
 import com.jaefan.munpyspring.user.presentation.feignClient.KakaoTokenFeignClient;
 import com.jaefan.munpyspring.user.presentation.feignClient.KakaoUserProfileFeignClient;
@@ -33,7 +33,7 @@ public class KakaoHttpClient {
 
 	private final KakaoUserProfileFeignClient kakaoUserProfileFeignClient; // 프로필 정보 요청을 보내는 FeignClient
 
-	public OAuthToken getTokenByCode(String code) {
+	public OAuthTokenDto getTokenByCode(String code) {
 		try {
 			return kakaoTokenFeignClient.getKakaoTokenByCode(
 				"authorization_code", // 고정값

--- a/src/main/java/com/jaefan/munpyspring/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/KakaoOAuthProvider.java
@@ -3,7 +3,7 @@ package com.jaefan.munpyspring.user.application;
 import org.springframework.stereotype.Service;
 
 import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,12 +13,12 @@ public class KakaoOAuthProvider {
 
 	private final KakaoHttpClient kakaoHttpClient; // HTTP 요청, 응답을 대리 수행해주는 객체
 
-	public OAuthToken getTokenByCode(String code) {
+	public OAuthTokenDto getTokenByCode(String code) {
 		return kakaoHttpClient.getTokenByCode(code);
 	}
 
-	public OAuthAccountDto getAccountByOAuthToken(OAuthToken oAuthToken) {
-		String authorization = "Bearer " + oAuthToken.getAccess_token();
+	public OAuthAccountDto getAccountByOAuthToken(OAuthTokenDto oAuthTokenDto) {
+		String authorization = "Bearer " + oAuthTokenDto.getAccess_token();
 		String propertyKeys = "[\"kakao_account.email\", \"kakao_account.profile\"]";
 
 		return kakaoHttpClient.getAccountByOAuthToken(authorization, propertyKeys);

--- a/src/main/java/com/jaefan/munpyspring/user/application/KakaoOAuthProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/KakaoOAuthProvider.java
@@ -1,0 +1,26 @@
+package com.jaefan.munpyspring.user.application;
+
+import org.springframework.stereotype.Service;
+
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthProvider {
+
+	private final KakaoHttpClient kakaoHttpClient; // HTTP 요청, 응답을 대리 수행해주는 객체
+
+	public OAuthToken getTokenByCode(String code) {
+		return kakaoHttpClient.getTokenByCode(code);
+	}
+
+	public OAuthAccountDto getAccountByOAuthToken(OAuthToken oAuthToken) {
+		String authorization = "Bearer " + oAuthToken.getAccess_token();
+		String propertyKeys = "[\"kakao_account.email\", \"kakao_account.profile\"]";
+
+		return kakaoHttpClient.getAccountByOAuthToken(authorization, propertyKeys);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/NaverHttpClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/NaverHttpClient.java
@@ -1,0 +1,67 @@
+package com.jaefan.munpyspring.user.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.exception.OAuthProcessingException;
+import com.jaefan.munpyspring.user.presentation.feignClient.NaverTokenFeignClient;
+import com.jaefan.munpyspring.user.presentation.feignClient.NaverUserProfileFeignClient;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * FeignClient를 사용해 HTTP 요청을 대리 수행해주는 컴포넌트
+ */
+@Component
+@RequiredArgsConstructor
+public class NaverHttpClient {
+
+	@Value("${oauth2.naver.api.client-id}")
+	private String clientId;
+
+	@Value("${oauth2.naver.api.client-secret}")
+	private String clientSecret;
+
+	@Value("${oauth2.naver.api.redirect-uri}")
+	private String redirectUri;
+
+	private final ObjectMapper objectMapper;
+
+	private final NaverTokenFeignClient naverTokenFeignClient; // 토큰발급 요청을 보내는 FeignClient
+
+	private final NaverUserProfileFeignClient naverUserProfileFeignClient; // 프로필 정보 요청을 보내는 FeignClient
+
+	public OAuthToken getTokenByCode(String code, String state) {
+		try {
+			return naverTokenFeignClient.getNaverTokenByCode(
+				"authorization_code",
+				clientId,
+				clientSecret,
+				code,
+				state
+			);
+		} catch (Exception ex) {
+			throw new OAuthProcessingException("Failed to process Naver OAuth");
+		}
+	}
+
+	public OAuthAccountDto getAccountByOAuthToken(String authorization) {
+		try {
+			ResponseEntity<String> profileResponse = naverUserProfileFeignClient.getKakaoUserProfile(authorization);
+
+			JsonNode rootNode = objectMapper.readTree(profileResponse.getBody());
+			JsonNode responseNode = rootNode.path("response");
+			String profileImageUrl = responseNode.path("profile_image").asText();
+			String email = responseNode.path("email").asText();
+
+			return new OAuthAccountDto(profileImageUrl, email);
+		} catch (Exception ex) {
+			throw new OAuthProcessingException("Failed to process Naver OAuth");
+		}
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/NaverHttpClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/NaverHttpClient.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 import com.jaefan.munpyspring.user.presentation.exception.OAuthProcessingException;
 import com.jaefan.munpyspring.user.presentation.feignClient.NaverTokenFeignClient;
 import com.jaefan.munpyspring.user.presentation.feignClient.NaverUserProfileFeignClient;
@@ -36,7 +36,7 @@ public class NaverHttpClient {
 
 	private final NaverUserProfileFeignClient naverUserProfileFeignClient; // 프로필 정보 요청을 보내는 FeignClient
 
-	public OAuthToken getTokenByCode(String code, String state) {
+	public OAuthTokenDto getTokenByCode(String code, String state) {
 		try {
 			return naverTokenFeignClient.getNaverTokenByCode(
 				"authorization_code",

--- a/src/main/java/com/jaefan/munpyspring/user/application/NaverOAuthProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/NaverOAuthProvider.java
@@ -3,7 +3,7 @@ package com.jaefan.munpyspring.user.application;
 import org.springframework.stereotype.Service;
 
 import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,12 +13,12 @@ public class NaverOAuthProvider {
 
 	private final NaverHttpClient naverHttpClient; // HTTP 요청, 응답을 대리 수행해주는 객체
 
-	public OAuthToken getTokenByCode(String code, String state) {
+	public OAuthTokenDto getTokenByCode(String code, String state) {
 		return naverHttpClient.getTokenByCode(code, state);
 	}
 
-	public OAuthAccountDto getAccountByOAuthToken(OAuthToken oAuthToken) {
-		String authorization = "Bearer " + oAuthToken.getAccess_token();
+	public OAuthAccountDto getAccountByOAuthToken(OAuthTokenDto oAuthTokenDto) {
+		String authorization = "Bearer " + oAuthTokenDto.getAccess_token();
 
 		return naverHttpClient.getAccountByOAuthToken(authorization);
 	}

--- a/src/main/java/com/jaefan/munpyspring/user/application/NaverOAuthProvider.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/NaverOAuthProvider.java
@@ -1,0 +1,25 @@
+package com.jaefan.munpyspring.user.application;
+
+import org.springframework.stereotype.Service;
+
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NaverOAuthProvider {
+
+	private final NaverHttpClient naverHttpClient; // HTTP 요청, 응답을 대리 수행해주는 객체
+
+	public OAuthToken getTokenByCode(String code, String state) {
+		return naverHttpClient.getTokenByCode(code, state);
+	}
+
+	public OAuthAccountDto getAccountByOAuthToken(OAuthToken oAuthToken) {
+		String authorization = "Bearer " + oAuthToken.getAccess_token();
+
+		return naverHttpClient.getAccountByOAuthToken(authorization);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/RandomNicknameService.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/RandomNicknameService.java
@@ -1,0 +1,50 @@
+package com.jaefan.munpyspring.user.application;
+
+import java.util.Random;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * OAuth 회원 랜덤 닉네임 생성기
+ */
+@Service
+@RequiredArgsConstructor
+public class RandomNicknameService {
+
+	private final UserRepository userRepository;
+
+	private final Random random = new Random();
+
+	private final String[] characters = {
+		"알알한", "앙칼진", "표독한", "귀여운", "순수한", "산만한", "똑똑한", "활발한", "조용한", "멋있는",
+		"아련한", "화난", "행복한", "온순한", "소심한", "느긋한", "차분한", "대담한", "외향적", "내향적",
+		"기쁜", "삐진"
+	};
+
+	private final String[] breeds = {
+		"치와와", "불독", "말티즈", "말티푸", "핀셔", "푸들", "시츄", "버먼", "비글", "하바니즈",
+		"퍼그", "테리어", "요크셔", "사모예드", "벵갈", "사바나", "랙돌", "봄베이", "메인쿤", "페르시안",
+		"스핑크스", "멍뭉이", "고양이", "강아지", "냐옹이"
+	};
+
+	public String generate() {
+		for (int i = 0; i < 3; i++) { // 랜덤 닉네임 생성 시도를 최대 3번까지 수행
+			String character = characters[random.nextInt(characters.length)];
+			String breed = breeds[random.nextInt(breeds.length)];
+			String numbers = "";
+			for (int j = 0; j < 4; j++) {
+				numbers += random.nextInt(10);
+			}
+			String nickname = character + breed + "_" + numbers;
+			if (!userRepository.existsByNickname(nickname)) { // 없는 닉네임인 경우 닉네임 리턴
+				return nickname;
+			}
+		}
+		return UUID.randomUUID().toString(); // 유니크한 랜덤 닉네임 생성 실패 시 uuid를 String으로 반환
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
@@ -1,0 +1,99 @@
+package com.jaefan.munpyspring.user.application;
+
+import static com.jaefan.munpyspring.user.domain.model.Provider.*;
+import static com.jaefan.munpyspring.user.domain.model.Role.*;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jaefan.munpyspring.common.exception.DuplicateEntityException;
+import com.jaefan.munpyspring.common.util.GoogleCloudStroageUploader;
+import com.jaefan.munpyspring.security.domain.model.JwtTokens;
+import com.jaefan.munpyspring.security.provider.JwtProvider;
+import com.jaefan.munpyspring.user.domain.model.Provider;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.UserSignUpRequestDto;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final RandomNicknameService randomNicknameService;
+
+	private final JwtProvider jwtProvider;
+
+	private final UserRepository userRepository;
+
+	private final GoogleCloudStroageUploader googleCloudStroageUploader;
+
+	private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+	private final static String DIR_NAME = "USER";
+
+	@Transactional
+	public JwtTokens signUpOrLogin(OAuthAccountDto oAuthAccountDto, Provider provider) {
+
+		// email로 유저를 찾고 없으면 User를 생성
+		User user = userRepository.findByEmail(oAuthAccountDto.getEmail())
+			.orElseGet(() -> OAuthAccountDto.toUser(oAuthAccountDto, randomNicknameService.generate(), provider, USER));
+
+		if (user.getProviderType() != provider) {
+			throw new DuplicateEntityException("이미 존재하는 이메일입니다.");
+		}
+
+		user.updateLastVisit();
+
+		user.updateProfileImage(oAuthAccountDto.getProfileImage()); // User의 프로필 url을 카카오 리소스 서버에서 가져온 url로 최신화
+
+		userRepository.save(user); // 요청자가 signUp인지 Login인지 구분없이 일괄 save 처리
+
+		return jwtProvider.createJwtTokensWithEmail(user.getEmail());
+	}
+
+	@Transactional
+	public JwtTokens signUp(UserSignUpRequestDto userSignUpRequestDto) throws IOException {
+
+		if (userRepository.existsByEmail(userSignUpRequestDto.getEmail())) {
+			throw new DuplicateEntityException("이미 존재하는 이메일입니다.");
+		}
+
+		if (userRepository.existsByNickname(userSignUpRequestDto.getNickname())) {
+			throw new DuplicateEntityException("이미 존재하는 닉네임입니다.");
+		}
+
+		String imageUrl = googleCloudStroageUploader.upload(userSignUpRequestDto.getProfileImage(), DIR_NAME);
+
+		User user = UserSignUpRequestDto.toUser(userSignUpRequestDto, imageUrl, DEFAULT, USER);
+
+		user.hashPassword(passwordEncoder);
+
+		userRepository.save(user);
+
+		return jwtProvider.createJwtTokensWithEmail(user.getEmail());
+	}
+
+	@Transactional
+	public void updateVisitAt(String email) {
+		User user = userRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
+		user.updateLastVisit();
+	}
+
+	public void find(UUID uuid) {
+		Optional<User> optionalUser = userRepository.findByUuid(uuid);
+	}
+
+	public String refreshAccessToken(String refreshToken) {
+		return jwtProvider.refreshAccessToken(refreshToken);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
@@ -74,7 +74,7 @@ public class UserService {
 
 		String imageUrl = googleCloudStroageUploader.upload(userSignUpRequestDto.getProfileImage(), DIR_NAME);
 
-		User user = UserSignUpRequestDto.toUser(userSignUpRequestDto, imageUrl, DEFAULT, USER);
+		User user = userSignUpRequestDto.toUser(imageUrl, DEFAULT, USER);
 
 		user.hashPassword(passwordEncoder);
 

--- a/src/main/java/com/jaefan/munpyspring/user/domain/model/Provider.java
+++ b/src/main/java/com/jaefan/munpyspring/user/domain/model/Provider.java
@@ -1,0 +1,5 @@
+package com.jaefan.munpyspring.user.domain.model;
+
+public enum Provider {
+	KAKAO, NAVER, DEFAULT
+}

--- a/src/main/java/com/jaefan/munpyspring/user/domain/model/Role.java
+++ b/src/main/java/com/jaefan/munpyspring/user/domain/model/Role.java
@@ -1,0 +1,5 @@
+package com.jaefan.munpyspring.user.domain.model;
+
+public enum Role {
+	USER, SHELTER
+}

--- a/src/main/java/com/jaefan/munpyspring/user/domain/model/Status.java
+++ b/src/main/java/com/jaefan/munpyspring/user/domain/model/Status.java
@@ -1,0 +1,5 @@
+package com.jaefan.munpyspring.user.domain.model;
+
+public enum Status {
+	ACTIVE, INACTIVE, DELETE
+}

--- a/src/main/java/com/jaefan/munpyspring/user/domain/model/User.java
+++ b/src/main/java/com/jaefan/munpyspring/user/domain/model/User.java
@@ -1,35 +1,81 @@
 package com.jaefan.munpyspring.user.domain.model;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
-import com.jaefan.munpyspring.animal.domain.model.ProtectionStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users", indexes = {
+	@Index(name = "idx_uuid", columnList = "uuid"),
+	@Index(name = "idx_email", columnList = "email")
+})
 public class User {
 	@Id
+	@Column(name = "user_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false, unique = true)
+	private UUID uuid;
+
+	@Column(length = 50, nullable = false)
 	private String nickname;
 
-	private String s3Url;
+	@Column(name = "profile_image", length = 255)
+	private String profileImage;
 
-	// private Provider providerType; SignUp 기능 구현 필요
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider_type", nullable = false)
+	private Provider providerType;
 
+	@Column(length = 255, nullable = false)
 	private String email;
 
-	private ProtectionStatus protectionStatus;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Status status;
 
+	@Column(length = 255, nullable = false)
+	private String password;
+
+	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
+	@Column(name = "visited_at")
 	private LocalDateTime visitedAt;
 
-	// private Role role; SignUp 기능 구현 필요
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Role role;
+
+	public void updateLastVisit() {
+		this.visitedAt = LocalDateTime.now();
+	}
+
+	public void updateProfileImage(String imageUrl) {
+		this.profileImage = imageUrl;
+	}
+
+	public void hashPassword(PasswordEncoder passwordEncoder) {
+		this.password = passwordEncoder.encode(this.password);
+	}
 }

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/Oauth2Controller.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/Oauth2Controller.java
@@ -1,0 +1,62 @@
+package com.jaefan.munpyspring.user.presentation;
+
+import static com.jaefan.munpyspring.user.domain.model.Provider.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jaefan.munpyspring.common.util.CookieUtil;
+import com.jaefan.munpyspring.security.domain.model.JwtTokens;
+import com.jaefan.munpyspring.user.application.KakaoOAuthProvider;
+import com.jaefan.munpyspring.user.application.NaverOAuthProvider;
+import com.jaefan.munpyspring.user.application.UserService;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class Oauth2Controller {
+
+	private final KakaoOAuthProvider kakaoOAuthProvider;
+
+	private final NaverOAuthProvider naverOAuthProvider;
+
+	private final UserService userService;
+
+	private final CookieUtil cookieUtil;
+
+	@GetMapping("/auth/kakao/callback")
+	public ResponseEntity<String> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
+		OAuthToken tokenByCode = kakaoOAuthProvider.getTokenByCode(code); // 카카오 계정 정보 요청을 위한 인증 토큰
+		OAuthAccountDto oAuthAccountDto = kakaoOAuthProvider.getAccountByOAuthToken(tokenByCode); // 카카오 계정 정보 DTO
+		JwtTokens jwtTokens = userService.signUpOrLogin(oAuthAccountDto, KAKAO); // 액세스, 리프래쉬 토큰 2개를 jwtTokens에 동시에 바인딩.
+
+		addJwtCookiesToResponse(jwtTokens, response); // 액세스 쿠키, 리프래쉬 쿠기 2개를 생성하고 응답에 담는 메소드
+		return new ResponseEntity<>("login success", HttpStatus.OK);
+	}
+
+	@GetMapping("/auth/naver/callback")
+	public ResponseEntity<String> naverCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) {
+		OAuthToken tokenByCode = naverOAuthProvider.getTokenByCode(code, state);
+		OAuthAccountDto oAuthAccountDto = naverOAuthProvider.getAccountByOAuthToken(tokenByCode);
+		JwtTokens jwtTokens = userService.signUpOrLogin(oAuthAccountDto, NAVER);
+
+		addJwtCookiesToResponse(jwtTokens, response);
+		return new ResponseEntity<>("login success", HttpStatus.OK);
+	}
+
+	// 로그인 성공 시 쿠키에 액세스, 리프레쉬 토큰 포함 응답.
+	private void addJwtCookiesToResponse(JwtTokens jwtTokens, HttpServletResponse response) {
+		Cookie accessCookie = cookieUtil.generateAccessCookie(jwtTokens.getAccessToken());
+		Cookie refreshCookie = cookieUtil.generateRefreshCookie(jwtTokens.getRefreshToken());
+		response.addCookie(accessCookie);
+		response.addCookie(refreshCookie);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/Oauth2Controller.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/Oauth2Controller.java
@@ -14,7 +14,7 @@ import com.jaefan.munpyspring.user.application.KakaoOAuthProvider;
 import com.jaefan.munpyspring.user.application.NaverOAuthProvider;
 import com.jaefan.munpyspring.user.application.UserService;
 import com.jaefan.munpyspring.user.presentation.dto.OAuthAccountDto;
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,7 +34,7 @@ public class Oauth2Controller {
 
 	@GetMapping("/auth/kakao/callback")
 	public ResponseEntity<String> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
-		OAuthToken tokenByCode = kakaoOAuthProvider.getTokenByCode(code); // 카카오 계정 정보 요청을 위한 인증 토큰
+		OAuthTokenDto tokenByCode = kakaoOAuthProvider.getTokenByCode(code); // 카카오 계정 정보 요청을 위한 인증 토큰
 		OAuthAccountDto oAuthAccountDto = kakaoOAuthProvider.getAccountByOAuthToken(tokenByCode); // 카카오 계정 정보 DTO
 		JwtTokens jwtTokens = userService.signUpOrLogin(oAuthAccountDto, KAKAO); // 액세스, 리프래쉬 토큰 2개를 jwtTokens에 동시에 바인딩.
 
@@ -44,7 +44,7 @@ public class Oauth2Controller {
 
 	@GetMapping("/auth/naver/callback")
 	public ResponseEntity<String> naverCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response) {
-		OAuthToken tokenByCode = naverOAuthProvider.getTokenByCode(code, state);
+		OAuthTokenDto tokenByCode = naverOAuthProvider.getTokenByCode(code, state);
 		OAuthAccountDto oAuthAccountDto = naverOAuthProvider.getAccountByOAuthToken(tokenByCode);
 		JwtTokens jwtTokens = userService.signUpOrLogin(oAuthAccountDto, NAVER);
 

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.jaefan.munpyspring.common.util.CookieUtil;
 import com.jaefan.munpyspring.user.application.UserService;
-import com.jaefan.munpyspring.user.presentation.dto.RefreshTokenRequest;
+import com.jaefan.munpyspring.user.presentation.dto.RefreshTokenRequestDto;
 import com.jaefan.munpyspring.user.presentation.dto.UserSignUpRequestDto;
 
 import io.jsonwebtoken.JwtException;
@@ -23,7 +23,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -31,7 +31,7 @@ public class UserController {
 
 	private final CookieUtil cookieUtil;
 
-	@PostMapping("/user")
+	@PostMapping
 	public ResponseEntity<String> signUp(@Valid @ModelAttribute UserSignUpRequestDto userSignUpRequestDto) throws
 		IOException {
 		userService.signUp(userSignUpRequestDto);
@@ -39,7 +39,7 @@ public class UserController {
 	}
 
 	@PostMapping("/refresh")
-	public ResponseEntity<String> refreshAccessToken(@RequestBody RefreshTokenRequest refreshToken, HttpServletResponse response) {
+	public ResponseEntity<String> refreshAccessToken(@RequestBody RefreshTokenRequestDto refreshToken, HttpServletResponse response) {
 		try {
 			String newAccessToken = userService.refreshAccessToken(refreshToken.getRefreshToken());
 			Cookie accessCookie = cookieUtil.generateAccessCookie(newAccessToken);

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
@@ -1,0 +1,64 @@
+package com.jaefan.munpyspring.user.presentation;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jaefan.munpyspring.common.util.CookieUtil;
+import com.jaefan.munpyspring.user.application.UserService;
+import com.jaefan.munpyspring.user.presentation.dto.RefreshTokenRequest;
+import com.jaefan.munpyspring.user.presentation.dto.UserSignUpRequestDto;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	private final CookieUtil cookieUtil;
+
+	@PostMapping("/user")
+	public ResponseEntity<String> signUp(@Valid @ModelAttribute UserSignUpRequestDto userSignUpRequestDto) throws
+		IOException {
+		userService.signUp(userSignUpRequestDto);
+		return new ResponseEntity<>("signUp Success", CREATED);
+	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<String> refreshAccessToken(@RequestBody RefreshTokenRequest refreshToken, HttpServletResponse response) {
+		try {
+			String newAccessToken = userService.refreshAccessToken(refreshToken.getRefreshToken());
+			Cookie accessCookie = cookieUtil.generateAccessCookie(newAccessToken);
+			response.addCookie(accessCookie);
+			return new ResponseEntity<>("Access token refreshed successfully.", OK);
+		} catch (JwtException ex) {
+			return new ResponseEntity<>("Refresh token is invalid please login again.", UNAUTHORIZED);
+		}
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(HttpServletResponse response) {
+		// "access_token"과 "refresh_token" 쿠키를 삭제
+		Cookie accessTokenCookie = cookieUtil.deleteCookie("access_token");
+		Cookie refreshTokenCookie = cookieUtil.deleteCookie("refresh_token");
+
+		response.addCookie(accessTokenCookie);
+		response.addCookie(refreshTokenCookie);
+
+		return new ResponseEntity<>("Logout success", OK);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthAccountDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthAccountDto.java
@@ -1,0 +1,39 @@
+package com.jaefan.munpyspring.user.presentation.dto;
+
+import static com.jaefan.munpyspring.user.domain.model.Status.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.jaefan.munpyspring.user.domain.model.Provider;
+import com.jaefan.munpyspring.user.domain.model.Role;
+import com.jaefan.munpyspring.user.domain.model.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * OAuth 계정 정보를 포함한 Dto
+ */
+@Getter
+@AllArgsConstructor
+public class OAuthAccountDto {
+
+	private String profileImage; // url
+
+	private String email;
+
+	public static User toUser(OAuthAccountDto oAuthAccountDto, String nickname, Provider providerType, Role role) {
+		return User.builder()
+			.uuid(UUID.randomUUID())
+			.nickname(nickname)
+			.profileImage(oAuthAccountDto.getProfileImage())
+			.providerType(providerType)
+			.email(oAuthAccountDto.getEmail())
+			.status(ACTIVE)
+			.password("")
+			.createdAt(LocalDateTime.now())
+			.role(role)
+			.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthToken.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthToken.java
@@ -1,0 +1,20 @@
+package com.jaefan.munpyspring.user.presentation.dto;
+
+import lombok.Getter;
+
+/**
+ * OAuth Token으로 사용자 정보인 OAuthAccountDto를 받기 위해 필요한 토큰
+ */
+@Getter
+public class OAuthToken {
+
+	private String token_type;
+
+	private String access_token;
+
+	private String refresh_token;
+
+	private int expires_in;
+
+	private int refresh_token_expires_in;
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthTokenDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/OAuthTokenDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
  * OAuth Token으로 사용자 정보인 OAuthAccountDto를 받기 위해 필요한 토큰
  */
 @Getter
-public class OAuthToken {
+public class OAuthTokenDto {
 
 	private String token_type;
 

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package com.jaefan.munpyspring.user.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 액세스 토큰 재발급을 위한 리프래쉬 토큰 Dto
+ */
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+	private String refreshToken;
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/RefreshTokenRequestDto.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
-public class RefreshTokenRequest {
+public class RefreshTokenRequestDto {
 	private String refreshToken;
 }

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
@@ -1,0 +1,46 @@
+package com.jaefan.munpyspring.user.presentation.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.jaefan.munpyspring.user.domain.model.Provider;
+import com.jaefan.munpyspring.user.domain.model.Role;
+import com.jaefan.munpyspring.user.domain.model.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 일반 회원가입 요청 Dto
+ */
+@Getter
+@AllArgsConstructor
+public class UserSignUpRequestDto {
+	
+	@NotBlank
+	@Pattern(regexp = "^(?! ).*(?<! )$", message = "닉네임의 앞이나 뒤에 공백이 올 수 없습니다.")
+	@Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_ ]{2,50}$", message = "닉네임은 특수문자를 제외한 2~50자리여야 합니다.")
+	private String nickname;
+
+	private MultipartFile profileImage;
+
+	@NotBlank
+	@Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank
+	@Pattern(regexp = "^[\\S]{8,16}$", message = "비밀번호는 8~16자 공백 없이 입력해야 합니다.")
+	private String password;
+
+	public static User toUser(UserSignUpRequestDto userSignUpRequestDto, String imageUrl, Provider providerType, Role role) {
+		return User.builder()
+			.nickname(userSignUpRequestDto.getNickname())
+			.profileImage(imageUrl)
+			.providerType(providerType)
+			.email(userSignUpRequestDto.getEmail())
+			.password(userSignUpRequestDto.getPassword())
+			.role(role)
+			.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
@@ -1,5 +1,10 @@
 package com.jaefan.munpyspring.user.presentation.dto;
 
+import static com.jaefan.munpyspring.user.domain.model.Status.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import com.jaefan.munpyspring.user.domain.model.Provider;
@@ -35,11 +40,14 @@ public class UserSignUpRequestDto {
 
 	public User toUser(String imageUrl, Provider providerType, Role role) {
 		return User.builder()
+			.uuid(UUID.randomUUID())
 			.nickname(nickname)
 			.profileImage(imageUrl)
 			.providerType(providerType)
 			.email(email)
+			.status(ACTIVE)
 			.password(password)
+			.createdAt(LocalDateTime.now())
 			.role(role)
 			.build();
 	}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/dto/UserSignUpRequestDto.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserSignUpRequestDto {
-	
+
 	@NotBlank
 	@Pattern(regexp = "^(?! ).*(?<! )$", message = "닉네임의 앞이나 뒤에 공백이 올 수 없습니다.")
 	@Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_ ]{2,50}$", message = "닉네임은 특수문자를 제외한 2~50자리여야 합니다.")
@@ -33,13 +33,13 @@ public class UserSignUpRequestDto {
 	@Pattern(regexp = "^[\\S]{8,16}$", message = "비밀번호는 8~16자 공백 없이 입력해야 합니다.")
 	private String password;
 
-	public static User toUser(UserSignUpRequestDto userSignUpRequestDto, String imageUrl, Provider providerType, Role role) {
+	public User toUser(String imageUrl, Provider providerType, Role role) {
 		return User.builder()
-			.nickname(userSignUpRequestDto.getNickname())
+			.nickname(nickname)
 			.profileImage(imageUrl)
 			.providerType(providerType)
-			.email(userSignUpRequestDto.getEmail())
-			.password(userSignUpRequestDto.getPassword())
+			.email(email)
+			.password(password)
 			.role(role)
 			.build();
 	}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/exception/OAuthProcessingException.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/exception/OAuthProcessingException.java
@@ -1,0 +1,7 @@
+package com.jaefan.munpyspring.user.presentation.exception;
+
+public class OAuthProcessingException extends RuntimeException {
+	public OAuthProcessingException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoTokenFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoTokenFeignClient.java
@@ -5,7 +5,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 
 /**
  * 카카오 인증 서버로 토큰 발급 요청을 보내는 객체
@@ -13,7 +13,7 @@ import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
 @FeignClient(name = "KakaoTokenFeignClient", url = "https://kauth.kakao.com")
 public interface KakaoTokenFeignClient {
 	@PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-	OAuthToken getKakaoTokenByCode(
+	OAuthTokenDto getKakaoTokenByCode(
 		@RequestParam("grant_type") String grantType,
 		@RequestParam("client_id") String clientId,
 		@RequestParam("redirect_uri") String redirectUri,

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoTokenFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoTokenFeignClient.java
@@ -1,0 +1,22 @@
+package com.jaefan.munpyspring.user.presentation.feignClient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+
+/**
+ * 카카오 인증 서버로 토큰 발급 요청을 보내는 객체
+ */
+@FeignClient(name = "KakaoTokenFeignClient", url = "https://kauth.kakao.com")
+public interface KakaoTokenFeignClient {
+	@PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	OAuthToken getKakaoTokenByCode(
+		@RequestParam("grant_type") String grantType,
+		@RequestParam("client_id") String clientId,
+		@RequestParam("redirect_uri") String redirectUri,
+		@RequestParam("code") String code
+	);
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoUserProfileFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/KakaoUserProfileFeignClient.java
@@ -1,0 +1,20 @@
+package com.jaefan.munpyspring.user.presentation.feignClient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 카카오 리소스 서버로 사용자 정보 요청을 보내는 객체 (요청에 토큰 포함)
+ */
+@FeignClient(name = "KakaoUserProfileFeignClient", url = "https://kapi.kakao.com")
+public interface KakaoUserProfileFeignClient {
+	@PostMapping(value = "/v2/user/me", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	ResponseEntity<String> getKakaoUserProfile(
+		@RequestHeader("Authorization") String authorization, // 인증 토큰
+		@RequestParam("property_keys") String propertyKeys // 받아올 사용자 정보들 (email, profileImage)
+	);
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverTokenFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverTokenFeignClient.java
@@ -5,7 +5,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+import com.jaefan.munpyspring.user.presentation.dto.OAuthTokenDto;
 
 /**
  * 네이버 인증 서버로 토큰 발급 요청을 보내는 객체
@@ -13,7 +13,7 @@ import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
 @FeignClient(name = "NaverTokenFeignClient", url = "https://nid.naver.com")
 public interface NaverTokenFeignClient {
 	@PostMapping(value = "/oauth2.0/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-	OAuthToken getNaverTokenByCode(
+	OAuthTokenDto getNaverTokenByCode(
 		@RequestParam("grant_type") String grant_type,
 		@RequestParam("client_id") String client_id,
 		@RequestParam("client_secret") String client_secret,

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverTokenFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverTokenFeignClient.java
@@ -1,0 +1,23 @@
+package com.jaefan.munpyspring.user.presentation.feignClient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.jaefan.munpyspring.user.presentation.dto.OAuthToken;
+
+/**
+ * 네이버 인증 서버로 토큰 발급 요청을 보내는 객체
+ */
+@FeignClient(name = "NaverTokenFeignClient", url = "https://nid.naver.com")
+public interface NaverTokenFeignClient {
+	@PostMapping(value = "/oauth2.0/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	OAuthToken getNaverTokenByCode(
+		@RequestParam("grant_type") String grant_type,
+		@RequestParam("client_id") String client_id,
+		@RequestParam("client_secret") String client_secret,
+		@RequestParam("code") String code,
+		@RequestParam("state") String state
+	);
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverUserProfileFeignClient.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/NaverUserProfileFeignClient.java
@@ -1,0 +1,18 @@
+package com.jaefan.munpyspring.user.presentation.feignClient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/**
+ * 네이버 리소스 서버로 사용자 정보 요청을 보내는 객체 (요청에 토큰 포함)
+ */
+@FeignClient(name = "NaverUserProfileFeignClient", url = "https://openapi.naver.com")
+public interface NaverUserProfileFeignClient {
+	@PostMapping(value = "/v1/nid/me", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	ResponseEntity<String> getKakaoUserProfile(
+		@RequestHeader("Authorization") String authorization // 토큰
+	);
+}

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/OpenFeignConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/feignClient/OpenFeignConfig.java
@@ -1,0 +1,13 @@
+package com.jaefan.munpyspring.user.presentation.feignClient;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * EnableFeignClients에 선언된 경로부터 @FeignClient가 붙은 인터페이스들을 스프링 빈 등록하는 configuration.
+ */
+@Configuration
+@EnableFeignClients("com.jaefan.munpyspring.user.presentation.feignClient")
+public class OpenFeignConfig {
+
+}


### PR DESCRIPTION
# Feature: OAuth 가입 & 보호소 등록 기능 #14

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅ 개요
>  일반 회원 OAuth 가입 구현 (KAKAO,NAVER)
 보호소의 등록 기능 구현
 OAuth 로그인 성공 시 JWT 발급 기능

### ✅ 리뷰어가 꼭 봐줬으면 하는 부분
> 양이 좀 많습니다... 리뷰하는데 이해 안되는 점 있으면 바로 말씀해주세요😅

### ✅ ISSUE 번호
- #14 

### ✅ 참고 사항
> 총 7가지의 설정 값 추가가 필요합니다. (코드 상 "${~~~}" 로 돼 있는 애들)
1. GCSconfig 클래스의 keyFileLocation 값
2. GoogleCloudStorageUploader의 bucketName
3. KakaoHttpClient 클래스의 clientId & redirectUrl
4. NaverHttpClient 클래스의 clientId & clientSecret & redirectUri

3번,4번에 해당하는 값은 따로 공유하겠습니다.
1번,2번은 GCS의 설정 값이 어떻게 구성됐는지 확인해 봐야 할 것 같습니다.