### PR TITLE
실종 동물 DTO 수정 및 회원가입 중복 이메일 유저 조회 기능 추가

### DIFF
--- a/src/main/java/com/jaefan/munpyspring/animal/application/AnimalRegistrationService.java
+++ b/src/main/java/com/jaefan/munpyspring/animal/application/AnimalRegistrationService.java
@@ -3,6 +3,8 @@ package com.jaefan.munpyspring.animal.application;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,17 +13,26 @@ import com.jaefan.munpyspring.animal.domain.model.AnimalType;
 import com.jaefan.munpyspring.animal.domain.model.Breed;
 import com.jaefan.munpyspring.animal.domain.model.PublicAnimal;
 import com.jaefan.munpyspring.animal.domain.model.PublicAnimalImage;
+import com.jaefan.munpyspring.animal.domain.repository.BreedRepository;
 import com.jaefan.munpyspring.animal.domain.repository.PublicAnimalRepository;
 import com.jaefan.munpyspring.animal.presentation.dto.AnimalRegistrationDto;
 import com.jaefan.munpyspring.common.util.GoogleCloudStroageUploader;
+import com.jaefan.munpyspring.security.domain.model.CustomUserDetails;
 import com.jaefan.munpyspring.shelter.domain.model.Shelter;
+import com.jaefan.munpyspring.shelter.domain.repository.ShelterRepository;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class AnimalRegistrationService {
 	private final PublicAnimalRepository publicAnimalRepository;
+	private final BreedRepository breedRepository;
+	private final ShelterRepository shelterRepository;
+	private final UserRepository userRepository;
 	private final GoogleCloudStroageUploader GoogleCloudStroageUploader;
 
 	@Transactional
@@ -37,8 +48,9 @@ public class AnimalRegistrationService {
 
 		List<String> imageUrls = GoogleCloudStroageUploader.upload(animalRegistrationImages, typeString);
 
-		Shelter shelter = null; // Spring Context에서 Authentication 객체를 꺼내 현재 접속 보호소를 식별하는 코드 들어갈 자리
-		Breed breed = null; // AI 서버에 동물 이미지 또는 ImageUrl 전송 후 판정 품종 받아오는 코드 들어갈 자리 (새로운 품종 시 품종 신규 등록 필요)
+		Shelter shelter = getCurrentShelter(); // Spring Context에서 Authentication 객체를 꺼내 현재 접속 보호소를 식별
+		Breed breed = breedRepository.findByBreedName(animalRegistrationDto.getBreedName())
+			.orElseThrow(() -> new EntityNotFoundException("breed not found has name: " + animalRegistrationDto.getBreedName()));
 
 		PublicAnimal publicAnimal = AnimalRegistrationDto.toEntity(animalRegistrationDto, shelter, breed);
 		List<PublicAnimalImage> publicAnimalImages = imageUrls.stream()
@@ -47,5 +59,19 @@ public class AnimalRegistrationService {
 
 		publicAnimal.setPublicAnimalImages(publicAnimalImages); // setter로 동물 엔티티에 이미지 설정.
 		publicAnimalRepository.save(publicAnimal);
+	}
+
+	private Shelter getCurrentShelter() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+			CustomUserDetails userDetails = (CustomUserDetails)authentication.getPrincipal();
+			String email = userDetails.getEmail();
+			User user = userRepository.findByEmail(email)
+				.orElseThrow(() -> new EntityNotFoundException("user not found has email: " + email));
+			return shelterRepository.findByUser(user)
+				.orElseThrow(() -> new EntityNotFoundException("user is not shelter"));
+		}
+		throw new EntityNotFoundException("authentication not found");
 	}
 }

--- a/src/main/java/com/jaefan/munpyspring/animal/domain/model/PublicAnimal.java
+++ b/src/main/java/com/jaefan/munpyspring/animal/domain/model/PublicAnimal.java
@@ -2,6 +2,7 @@ package com.jaefan.munpyspring.animal.domain.model;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import com.jaefan.munpyspring.shelter.domain.model.Shelter;
 
@@ -76,14 +77,13 @@ public class PublicAnimal {
 
 	public PublicAnimal(
 		AnimalType type, AnimalGender gender, AnimalNeutered isNeutered, Boolean caution,
-		String noticeNo, LocalDateTime rescuedAt, String rescuePlace,
-		String rescueReason, Shelter shelter, Breed breed
+		LocalDateTime rescuedAt, String rescuePlace, String rescueReason, Shelter shelter, Breed breed
 	) {
 		this.type = type;
 		this.gender = gender;
 		this.isNeutered = isNeutered;
 		this.caution = caution;
-		this.noticeNo = noticeNo;
+		this.noticeNo = UUID.randomUUID().toString();
 		this.protectionStatus = ProtectionStatus.POSTED;
 		this.rescuedAt = rescuedAt;
 		this.rescuePlace = rescuePlace;

--- a/src/main/java/com/jaefan/munpyspring/animal/domain/repository/BreedRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/animal/domain/repository/BreedRepository.java
@@ -1,6 +1,7 @@
 package com.jaefan.munpyspring.animal.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,6 @@ public interface BreedRepository extends JpaRepository<Breed, Long> {
 
 	@Query("SELECT b FROM Breed b WHERE :family IS NULL OR b.family = :family")
 	List<Breed> findByFamily(String family);
+
+	Optional<Breed> findByBreedName(String name);
 }

--- a/src/main/java/com/jaefan/munpyspring/animal/presentation/dto/AnimalRegistrationDto.java
+++ b/src/main/java/com/jaefan/munpyspring/animal/presentation/dto/AnimalRegistrationDto.java
@@ -14,7 +14,6 @@ import com.jaefan.munpyspring.shelter.domain.model.Shelter;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,24 +22,23 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AnimalRegistrationDto {
 
-	@NotBlank
-	@Pattern(regexp = "DOG|CAT|OTHER", message = "축종은 DOG, CAT, OTHER 중 하나여야 합니다.")
+	@NotNull
+	// @Pattern(regexp = "DOG|CAT|OTHER", message = "축종은 DOG, CAT, OTHER 중 하나여야 합니다.")
 	private AnimalType type;
 
 	@NotBlank
-	@Pattern(regexp = "MALE|FEMALE|UNKNOWN", message = "성별은 MALE, FEMALE, UNKNOWN 중 하나여야 합니다.")
+	private String breedName;
+
+	@NotNull
+	// @Pattern(regexp = "MALE|FEMALE|UNKNOWN", message = "성별은 MALE, FEMALE, UNKNOWN 중 하나여야 합니다.")
 	private AnimalGender gender;
 
-	@NotBlank
-	@Pattern(regexp = "YES|NO|UNKNOWN", message = "중성화 여부는 YES, NO, UNKNOWN 중 하나여야 합니다.")
+	@NotNull
+	// @Pattern(regexp = "YES|NO|UNKNOWN", message = "중성화 여부는 YES, NO, UNKNOWN 중 하나여야 합니다.")
 	private AnimalNeutered isNeutered;
 
 	@NotNull
 	private Boolean caution;
-
-	@NotBlank
-	@Size(min = 1, max = 50, message = "공고번호는 1 ~ 50자 사이여야 합니다.")
-	private String noticeNo;
 
 	@NotNull
 	private List<MultipartFile> animalImages;
@@ -61,7 +59,6 @@ public class AnimalRegistrationDto {
 			animalRegistrationDTO.getGender(),
 			animalRegistrationDTO.getIsNeutered(),
 			animalRegistrationDTO.getCaution(),
-			animalRegistrationDTO.getNoticeNo(),
 			animalRegistrationDTO.getRescuedAt(),
 			animalRegistrationDTO.getRescuePlace(),
 			animalRegistrationDTO.getRescueReason(),

--- a/src/main/java/com/jaefan/munpyspring/shelter/domain/repository/ShelterRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/shelter/domain/repository/ShelterRepository.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jaefan.munpyspring.shelter.domain.model.Shelter;
+import com.jaefan.munpyspring.user.domain.model.User;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Long>, ShelterRepositoryCustom {
 
 	Optional<Shelter> findByName(String name);
+
+	Optional<Shelter> findByUser(User user);
 
 	Optional<Shelter> findByNameAndTelNo(String name, String telno);
 }

--- a/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
+++ b/src/main/java/com/jaefan/munpyspring/user/application/UserService.java
@@ -96,4 +96,8 @@ public class UserService {
 	public String refreshAccessToken(String refreshToken) {
 		return jwtProvider.refreshAccessToken(refreshToken);
 	}
+
+	public Boolean exists(String email) {
+		return userRepository.existsByEmail(email);
+	}
 }

--- a/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
+++ b/src/main/java/com/jaefan/munpyspring/user/presentation/UserController.java
@@ -5,10 +5,12 @@ import static org.springframework.http.HttpStatus.*;
 import java.io.IOException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jaefan.munpyspring.common.util.CookieUtil;
@@ -60,5 +62,13 @@ public class UserController {
 		response.addCookie(refreshTokenCookie);
 
 		return new ResponseEntity<>("Logout success", OK);
+	}
+
+	@GetMapping("/exists")
+	public ResponseEntity<Void> exists(@RequestParam String email) {
+		if (!userService.exists(email)) {
+			return new ResponseEntity<>(OK);
+		}
+		return new ResponseEntity<>(CONFLICT);
 	}
 }


### PR DESCRIPTION
# {이 부분에 PR 제목을 작성해주세요.}

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅ 개요
> 실종 동물 DTO의 NoticeNo를 없애고 백엔드 쪽에서 UUID로 발급
실종 동물 등록 시 품종 및 보호소 매핑하는 코드 추가
회원 가입 시 이메일 중복 유저 조회 기능 추가

### ✅ 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다
### ✅ ISSUE 번호
> 관련된 이슈 번호를 나열해주세요. 여러개 있다면 여러개 작성해주세요


### ✅ 참고 사항
> @NotBlank와 @Pattern을 일단은 주석 처리 해 놓았습니다. 지워도 되면 지운 후에 추가로 푸시 올리겠습니다!
