### PR TITLE
Feat: 보호동물 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-java:4.20.0'
     implementation 'io.github.bonigarcia:webdrivermanager:5.8.0'
 
+    // 채팅
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/jaefan/munpyspring/chat/application/ChatService.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/application/ChatService.java
@@ -45,14 +45,14 @@ public class ChatService {
 		Optional<ChatRoom> chatRoom = chatRoomRepository.findByUserIdAndProtectionAnimalId(userId, animalId);
 		if (chatRoom.isPresent()) {
 			Long roomId = chatRoom.get().getId();
-			return ChatEnterDto.init(userId, roomId, readInfiniteScroll(roomId, null));
+			return new ChatEnterDto(userId, roomId, readInfiniteScroll(roomId, null));
 		} else {
 			ProtectionAnimal protectionAnimal = protectionAnimalRepository.findById(animalId)
 				.orElseThrow(() -> new EntityNotFoundException());
 			User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException());
 			ChatRoom newChatRoom = ChatRoom.create(protectionAnimal, user, protectionAnimal.getShelter());
 			chatRoomRepository.save(newChatRoom);
-			return ChatEnterDto.init(userId, newChatRoom.getId(), Collections.emptyList());
+			return new ChatEnterDto(userId, newChatRoom.getId(), Collections.emptyList());
 		}
 	}
 

--- a/src/main/java/com/jaefan/munpyspring/chat/application/ChatService.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/application/ChatService.java
@@ -1,0 +1,68 @@
+package com.jaefan.munpyspring.chat.application;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jaefan.munpyspring.animal.domain.model.ProtectionAnimal;
+import com.jaefan.munpyspring.animal.domain.repository.ProtectionAnimalRepository;
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+import com.jaefan.munpyspring.chat.domain.ChatRoom;
+import com.jaefan.munpyspring.chat.domain.repository.ChatMessageRepository;
+import com.jaefan.munpyspring.chat.domain.repository.ChatRoomRepository;
+import com.jaefan.munpyspring.chat.event.ChatMessageSavedEvent;
+import com.jaefan.munpyspring.chat.presentation.dto.ChatEnterDto;
+import com.jaefan.munpyspring.chat.presentation.dto.ChatMessageDto;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ProtectionAnimalRepository protectionAnimalRepository;
+	private final UserRepository userRepository;
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	@Transactional
+	public void handleMessage(ChatMessageDto message) {
+		ChatMessage chatMessage = chatMessageRepository.save(
+			ChatMessage.create(message.getRoomId(), message.getSenderId(), message.getContent())
+		);
+		applicationEventPublisher.publishEvent(new ChatMessageSavedEvent(chatMessage));
+	}
+
+	@Transactional
+	public ChatEnterDto createOrGetChatRoom(Long userId, Long animalId) {
+		Optional<ChatRoom> chatRoom = chatRoomRepository.findByUserIdAndProtectionAnimalId(userId, animalId);
+		if (chatRoom.isPresent()) {
+			Long roomId = chatRoom.get().getId();
+			return ChatEnterDto.init(userId, roomId, readInfiniteScroll(roomId, null));
+		} else {
+			ProtectionAnimal protectionAnimal = protectionAnimalRepository.findById(animalId)
+				.orElseThrow(() -> new EntityNotFoundException());
+			User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException());
+			ChatRoom newChatRoom = ChatRoom.create(protectionAnimal, user, protectionAnimal.getShelter());
+			chatRoomRepository.save(newChatRoom);
+			return ChatEnterDto.init(userId, newChatRoom.getId(), Collections.emptyList());
+		}
+	}
+
+	public List<ChatMessageDto> readInfiniteScroll(Long roomId, Long lastMessageId) {
+		if (!chatRoomRepository.existsById(roomId)) {
+			throw new EntityNotFoundException();
+		}
+		List<ChatMessage> messages = lastMessageId == null ?
+			chatMessageRepository.readInfiniteScroll(roomId, 20L) :
+			chatMessageRepository.readInfiniteScroll(roomId, lastMessageId, 20L);
+		return messages.stream().map(ChatMessageDto::from).toList();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/domain/ChatMessage.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/domain/ChatMessage.java
@@ -1,0 +1,46 @@
+package com.jaefan.munpyspring.chat.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_message", indexes = {
+	@Index(name = "idx_room_message", columnList = "room_id, chat_message_id")
+})
+public class ChatMessage {
+	@Id
+	@Column(name = "chat_message_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long chatMessageId;
+
+	@Column(name = "room_id")
+	private Long roomId;
+
+	@Column(name = "sender_id")
+	private Long senderId;
+
+	private String content;
+
+	private LocalDateTime createdAt;
+
+	public static ChatMessage create(Long roomId, Long senderId, String content) {
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.roomId = roomId;
+		chatMessage.senderId = senderId;
+		chatMessage.content = content;
+		chatMessage.createdAt = LocalDateTime.now();
+		return chatMessage;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/domain/ChatRoom.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/domain/ChatRoom.java
@@ -1,0 +1,47 @@
+package com.jaefan.munpyspring.chat.domain;
+
+import com.jaefan.munpyspring.animal.domain.model.ProtectionAnimal;
+import com.jaefan.munpyspring.shelter.domain.model.Shelter;
+import com.jaefan.munpyspring.user.domain.model.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+	@Id
+	@Column(name = "chat_room_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "protection_animal_id")
+	private ProtectionAnimal protectionAnimal;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "shelter_id")
+	private Shelter shelter;
+
+	public static ChatRoom create(ProtectionAnimal protectionAnimal, User user, Shelter shelter) {
+		ChatRoom chatRoom = new ChatRoom();
+		chatRoom.protectionAnimal = protectionAnimal;
+		chatRoom.user = user;
+		chatRoom.shelter = shelter;
+		return chatRoom;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/domain/repository/ChatMessageRepository.java
@@ -1,0 +1,30 @@
+package com.jaefan.munpyspring.chat.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+	@Query(
+		value = "select * "
+			+ "from chat_message "
+			+ "where room_id = :roomId "
+			+ "order by chat_message_id desc "
+			+ "limit :limit",
+		nativeQuery = true
+	)
+	List<ChatMessage> readInfiniteScroll(Long roomId, Long limit);
+
+	@Query(
+		value = "select * "
+			+ "from chat_message "
+			+ "where room_id = :roomId And chat_message_id < :lastMessageId "
+			+ "order by chat_message_id desc "
+			+ "limit :limit",
+		nativeQuery = true
+	)
+	List<ChatMessage> readInfiniteScroll(Long roomId, Long lastMessageId, Long limit);
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/domain/repository/ChatRoomRepository.java
@@ -1,0 +1,12 @@
+package com.jaefan.munpyspring.chat.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jaefan.munpyspring.chat.domain.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+	// 사용자 ID와 유기견 ID로 채팅방을 찾는 메소드 (나의 채팅 목록이 아닌 동물 상세 페이지에서 채팅하기 클릭 시 발생)
+	Optional<ChatRoom> findByUserIdAndProtectionAnimalId(Long userId, Long animalId);
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/event/ChatMessageSavedEvent.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/event/ChatMessageSavedEvent.java
@@ -1,0 +1,12 @@
+package com.jaefan.munpyspring.chat.event;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatMessageSavedEvent {
+	private final ChatMessage chatMessage;
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/event/handler/ChatMessageEventHandler.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/event/handler/ChatMessageEventHandler.java
@@ -1,0 +1,24 @@
+package com.jaefan.munpyspring.chat.event.handler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+import com.jaefan.munpyspring.chat.event.ChatMessageSavedEvent;
+import com.jaefan.munpyspring.chat.messaging.RabbitMqClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventHandler {
+
+	private final RabbitMqClient rabbitMqClient;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ChatMessageSavedEvent event) {
+		ChatMessage message = event.getChatMessage();
+		rabbitMqClient.sendMessage(message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageController.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageController.java
@@ -1,0 +1,24 @@
+package com.jaefan.munpyspring.chat.messaging;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import com.jaefan.munpyspring.chat.application.ChatService;
+import com.jaefan.munpyspring.chat.presentation.dto.ChatMessageDto;
+
+@Controller
+public class MessageController {
+
+	@Autowired
+	private RabbitMqClient rabbitMqClient;
+
+	@Autowired
+	private ChatService messageService;
+
+	// 클라이언트에서 "/app/chat"로 보낸 메시지를 처리
+	@MessageMapping("/chat")
+	public void sendMessage(ChatMessageDto message) {
+		messageService.handleMessage(message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageController.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageController.java
@@ -7,14 +7,13 @@ import org.springframework.stereotype.Controller;
 import com.jaefan.munpyspring.chat.application.ChatService;
 import com.jaefan.munpyspring.chat.presentation.dto.ChatMessageDto;
 
+import lombok.RequiredArgsConstructor;
+
 @Controller
+@RequiredArgsConstructor
 public class MessageController {
 
-	@Autowired
-	private RabbitMqClient rabbitMqClient;
-
-	@Autowired
-	private ChatService messageService;
+	private final ChatService messageService;
 
 	// 클라이언트에서 "/app/chat"로 보낸 메시지를 처리
 	@MessageMapping("/chat")

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageListener.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageListener.java
@@ -1,0 +1,28 @@
+package com.jaefan.munpyspring.chat.messaging;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+
+@Component
+public class MessageListener {
+
+	@Autowired
+	private SimpMessagingTemplate messagingTemplate;
+
+	@Autowired
+	private RabbitConstant rabbitConstant;
+
+	public MessageListener(SimpMessagingTemplate messagingTemplate) {
+		this.messagingTemplate = messagingTemplate;
+	}
+
+	@RabbitListener(queues = "#{rabbitConstant.getQueueName()}")
+	public void receiveMessage(ChatMessage message) {
+		String roomId = String.valueOf(message.getRoomId());
+		messagingTemplate.convertAndSend("/topic/chat/" + roomId, message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageListener.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/MessageListener.java
@@ -1,24 +1,19 @@
 package com.jaefan.munpyspring.chat.messaging;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import com.jaefan.munpyspring.chat.domain.ChatMessage;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class MessageListener {
+	private final SimpMessagingTemplate messagingTemplate;
 
-	@Autowired
-	private SimpMessagingTemplate messagingTemplate;
-
-	@Autowired
-	private RabbitConstant rabbitConstant;
-
-	public MessageListener(SimpMessagingTemplate messagingTemplate) {
-		this.messagingTemplate = messagingTemplate;
-	}
+	private final RabbitConstant rabbitConstant;
 
 	@RabbitListener(queues = "#{rabbitConstant.getQueueName()}")
 	public void receiveMessage(ChatMessage message) {

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/RabbitConstant.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/RabbitConstant.java
@@ -1,0 +1,21 @@
+package com.jaefan.munpyspring.chat.messaging;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class RabbitConstant {
+	private String queueName;
+
+	@PostConstruct
+	public void init() {
+		this.queueName = "queue-" + UUID.randomUUID().toString();
+	}
+
+	public String getQueueName() {
+		return queueName;
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/messaging/RabbitMqClient.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/messaging/RabbitMqClient.java
@@ -1,0 +1,17 @@
+package com.jaefan.munpyspring.chat.messaging;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+
+@Component
+public class RabbitMqClient {
+	@Autowired
+	private RabbitTemplate rabbitTemplate;
+
+	public void sendMessage(ChatMessage message) {
+		rabbitTemplate.convertAndSend("Mungpy", "", message);
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/ChatController.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/ChatController.java
@@ -1,0 +1,56 @@
+package com.jaefan.munpyspring.chat.presentation;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jaefan.munpyspring.chat.application.ChatService;
+import com.jaefan.munpyspring.chat.presentation.dto.ChatEnterDto;
+import com.jaefan.munpyspring.chat.presentation.dto.ChatMessageDto;
+import com.jaefan.munpyspring.user.domain.model.User;
+import com.jaefan.munpyspring.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+	private final ChatService chatService;
+	private final UserRepository userRepository;
+
+	@GetMapping("/rooms/{roomId}")
+	public ChatEnterDto initChatRoom(@PathVariable Long roomId) {
+		Long userId = getCurrentUserId();
+		List<ChatMessageDto> messages = chatService.readInfiniteScroll(roomId, null);
+
+		return ChatEnterDto.init(userId, roomId, messages);
+	}
+
+	@GetMapping("/animals/{animalId}")
+	public ChatEnterDto getChatRoom(@PathVariable Long animalId) {
+		Long userId = getCurrentUserId();
+		return chatService.createOrGetChatRoom(userId, animalId);
+	}
+
+	@GetMapping("/rooms/{roomId}/messages")
+	public List<ChatMessageDto> loadPreviousMessage(
+		@PathVariable Long roomId,
+		@RequestParam(required = false) Long lastMessageId
+	) {
+		return chatService.readInfiniteScroll(roomId, lastMessageId);
+	}
+
+	private Long getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String email = authentication.getName();
+		User user = userRepository.findByEmail(email).orElseThrow();
+		return user.getId();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/ChatController.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/ChatController.java
@@ -30,7 +30,7 @@ public class ChatController {
 		Long userId = getCurrentUserId();
 		List<ChatMessageDto> messages = chatService.readInfiniteScroll(roomId, null);
 
-		return ChatEnterDto.init(userId, roomId, messages);
+		return new ChatEnterDto(userId, roomId, messages);
 	}
 
 	@GetMapping("/animals/{animalId}")

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatEnterDto.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatEnterDto.java
@@ -13,12 +13,4 @@ public class ChatEnterDto {
 	private Long userId;
 	private Long roomId;
 	private List<ChatMessageDto> messages;
-
-	public static ChatEnterDto init(Long userId, Long roomId, List<ChatMessageDto> messages) {
-		return ChatEnterDto.builder()
-			.userId(userId)
-			.roomId(roomId)
-			.messages(messages)
-			.build();
-	}
 }

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatEnterDto.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatEnterDto.java
@@ -1,0 +1,24 @@
+package com.jaefan.munpyspring.chat.presentation.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ChatEnterDto {
+	private Long userId;
+	private Long roomId;
+	private List<ChatMessageDto> messages;
+
+	public static ChatEnterDto init(Long userId, Long roomId, List<ChatMessageDto> messages) {
+		return ChatEnterDto.builder()
+			.userId(userId)
+			.roomId(roomId)
+			.messages(messages)
+			.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatMessageDto.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatMessageDto.java
@@ -1,0 +1,30 @@
+package com.jaefan.munpyspring.chat.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import com.jaefan.munpyspring.chat.domain.ChatMessage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ChatMessageDto {
+	private Long chatMessageId;
+	private Long roomId;
+	private Long senderId;
+	private String content;
+	private LocalDateTime createdAt;
+
+	public static ChatMessageDto from(ChatMessage message) {
+		return ChatMessageDto.builder()
+			.chatMessageId(message.getChatMessageId())
+			.roomId(message.getRoomId())
+			.senderId(message.getSenderId())
+			.content(message.getContent())
+			.createdAt(message.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatRoomDto.java
+++ b/src/main/java/com/jaefan/munpyspring/chat/presentation/dto/ChatRoomDto.java
@@ -1,0 +1,10 @@
+package com.jaefan.munpyspring.chat.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomDto {
+	private Long roomId;
+}

--- a/src/main/java/com/jaefan/munpyspring/common/config/RabbitConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/common/config/RabbitConfig.java
@@ -1,0 +1,52 @@
+package com.jaefan.munpyspring.common.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.FanoutExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.jaefan.munpyspring.chat.messaging.RabbitConstant;
+
+@EnableRabbit
+@Configuration
+public class RabbitConfig {
+
+	@Autowired
+	private RabbitConstant rabbitConstant;
+
+	@Bean
+	public FanoutExchange exchange() {
+		return new FanoutExchange("Mungpy");
+	}
+
+	@Bean
+	public Queue queue() {
+		// 동적으로 큐 이름을 RabbitConstant에서 가져옴
+		return new Queue(rabbitConstant.getQueueName());
+	}
+
+	@Bean
+	public Binding binding(Queue queue, FanoutExchange exchange) {
+		return BindingBuilder.bind(queue).to(exchange);
+	}
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+		rabbitTemplate.setMessageConverter(jsonMessageConverter());
+
+		return rabbitTemplate;
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter jsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+}

--- a/src/main/java/com/jaefan/munpyspring/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/common/config/WebSecurityConfig.java
@@ -62,6 +62,8 @@ public class WebSecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(POST, "/api/animal").hasRole("SHELTER") // 동물 등록은 보호소만 가능.
+				.requestMatchers("/api/chat/rooms/**").authenticated() // 특정 채팅방 입장은 인증 필요
+				.requestMatchers("/api/chat/animals/**").authenticated() // 보호 동물 채팅방 입장 시 인증 필요
 				.anyRequest()
 				.permitAll())
 			.formLogin(form -> form.disable())

--- a/src/main/java/com/jaefan/munpyspring/common/config/WebSocketConfig.java
+++ b/src/main/java/com/jaefan/munpyspring/common/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.jaefan.munpyspring.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();  // WebSocket 연결을 위한 엔드포인트
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.setApplicationDestinationPrefixes("/app");  // 메시지 전송 경로
+		registry.enableSimpleBroker("/topic");  // 구독을 위한 브로커
+	}
+}


### PR DESCRIPTION
# Feat: 보호동물 채팅 기능 구현

### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅ 개요
> 보호 동물 입양 문의를 위한 채팅 기능을 구현했습니다.

### ✅ 리뷰어가 꼭 봐줬으면 하는 부분
> 채팅 내용을 MongoDB가 아닌 MySQL에 저장했습니다. 따라서 인덱스 설정과 쿼리를 나름 최대한 효율적으로 작성했다고 생각하는데, ChatMessage의 복합 인덱스와 ChatMessageRepository의 네이티브 쿼리가 적절하게 설계됐는지 중점적으로 봐주시면 감사하겠습니다.
### ✅ ISSUE 번호
> 

### ✅ 참고 사항
> 리뷰하시다 궁금한 점은 바로 물어봐주세요.
